### PR TITLE
feat: Add client key authentication and Docker Compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,16 @@ docker run -it --rm -p 3000:3000 jackzzs/cloudflyer -K YOUR_CLIENT_KEY
 Docker Compose:
 
 ```yaml
-version: 3
 services:
   cloudflyer:
-    image: jackzzs/cloudflyer
+    build: .
+    image: cloudflyer:latest
     container_name: cloudflyer
-    restart: unless-stopped
     ports:
       - 3000:3000
+    command: >
+      -K "YOUR_API_KEY" 
+      -H "0.0.0.0"
 ```
 
 ## API Endpoints for Server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+services:
+  cloudflyer:
+    build: .
+    image: cloudflyer:latest
+    container_name: cloudflyer
+    ports:
+      - "3000:3000"
+    command: >
+      -K "YOUR_API_KEY" 
+      -H "0.0.0.0"

--- a/docker_startup.sh
+++ b/docker_startup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "Starting Cloudflyer with arguments: $@"
+
 exec /dockerstartup/vnc_startup.sh  > /dev/null 2>&1 &
 
 cd /app

--- a/test.py
+++ b/test.py
@@ -41,7 +41,7 @@ def create_task(data):
     return response.json()
 
 
-def get_task_result(task_id, client_key="123456"):
+def get_task_result(task_id, client_key=EXAMPLE_TOKEN):
     headers = {"Content-Type": "application/json"}
 
     data = {"clientKey": client_key, "taskId": task_id}
@@ -70,9 +70,9 @@ def start_server():
     return t
 
 
-def poll_task_result(task_id) -> dict:
+def poll_task_result(task_id, client_key) -> dict:
     while True:
-        cf_response = get_task_result(task_id)
+        cf_response = get_task_result(task_id, client_key)
         if cf_response["status"] == "completed":
             return cf_response["result"]
         time.sleep(3)
@@ -93,7 +93,7 @@ def cloudflare_challenge(proxy=None):
         data["proxy"] = proxy
 
     task_info = create_task(data)
-    result = poll_task_result(task_info["taskId"])
+    result = poll_task_result(task_info["taskId"], data["clientKey"])
     print(f"Challenge result:\n{json.dumps(result, indent=2)}")
 
     success = verify_cloudflare_challenge(result)
@@ -117,7 +117,7 @@ def turnstile(proxy=None):
     print("Task:")
     print(json.dumps(data, indent=2))
     task_info = create_task(data)
-    result = poll_task_result(task_info["taskId"])
+    result = poll_task_result(task_info["taskId"], data["clientKey"])
     print(f"Turnstile result:\n{json.dumps(result, indent=2)}")
 
 
@@ -145,7 +145,7 @@ def recapcha_invisible(proxy=None):
         data["proxy"] = proxy
 
     task_info = create_task(data)
-    result = poll_task_result(task_info["taskId"])
+    result = poll_task_result(task_info["taskId"], data["clientKey"])
     print(f"Challenge result:\n{json.dumps(result, indent=2)}")
 
 def parse_proxy_string(proxy_str):


### PR DESCRIPTION
This commit introduces server-side authentication using a client key.

- The server can now be started with a `-K` or `--clientKey` argument.
- API endpoints `/createTask` and `/getTaskResult` now validate this key.
- The `/getTaskResult` endpoint now returns a JSON error for missing tasks instead of a 404, improving the client polling experience.

Additionally, a `docker-compose.yaml` file has been added to simplify local deployment, and the test suite has been updated to accommodate these changes.